### PR TITLE
[CIR-2149] Reads labels response from Journey Data and determine En/Cy message based on PLAY_LANG Cookie

### DIFF
--- a/app/models/Journey.scala
+++ b/app/models/Journey.scala
@@ -17,6 +17,7 @@
 package models
 
 import play.api.libs.json.{Json, Reads, Writes}
+import play.api.mvc.RequestHeader
 
 case class Journey(
   accessibilityStatementUrl: String,
@@ -24,8 +25,25 @@ case class Journey(
   enterEmailUrl:             Option[String],
   backUrl:                   Option[String],
   serviceTitle:              Option[String],
-  emailAddress:              Option[String]
-)
+  emailAddress:              Option[String],
+  labels:                    Option[MessageLabels]
+) {
+
+  def serviceTitleMessage(implicit request: RequestHeader): Option[String] = {
+
+    val isWelsh = request.cookies.get("PLAY_LANG").map(_.value).contains("cy")
+    val welshTitle = labels.flatMap(_.cy.pageTitle)
+    val englishTitle = labels.flatMap(_.en.pageTitle)
+
+    if (isWelsh && welshTitle.isDefined) {
+      welshTitle
+    } else if (englishTitle.isDefined) {
+      englishTitle
+    } else {
+      serviceTitle
+    }
+  }
+}
 
 object Journey {
   implicit val reads:  Reads[Journey] = Json.reads[Journey]

--- a/app/models/MessageLabel.scala
+++ b/app/models/MessageLabel.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Format, Json}
+
+case class MessageLabel(pageTitle: Option[String], userFacingServiceName: Option[String])
+
+object MessageLabel {
+  implicit val format: Format[MessageLabel] = Json.format
+}

--- a/app/models/MessageLabels.scala
+++ b/app/models/MessageLabels.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Format, Json}
+
+case class MessageLabels(en: MessageLabel, cy: MessageLabel)
+
+object MessageLabels {
+  implicit val format: Format[MessageLabels] = Json.format
+}

--- a/app/views/EmailForm.scala.html
+++ b/app/views/EmailForm.scala.html
@@ -39,7 +39,7 @@
     pageTitle = Some(pageTitle),
     accessibilityStatementUrl = journey.map(_.accessibilityStatementUrl),
     backUrl = journey.flatMap(_.backUrl),
-    serviceTitle = journey.flatMap(_.serviceTitle),
+    serviceTitle = journey.flatMap(_.serviceTitleMessage),
     deskproServiceName = journey.map(_.deskproServiceName)
 ) {
     @errorSummary(formData)

--- a/app/views/HybridPasscodeForm.scala.html
+++ b/app/views/HybridPasscodeForm.scala.html
@@ -72,7 +72,7 @@
     pageTitle = Some(pageTitle),
     accessibilityStatementUrl = Some(journey.accessibilityStatementUrl),
     backUrl = journey.backUrl,
-    serviceTitle = journey.serviceTitle,
+    serviceTitle = journey.serviceTitleMessage,
     deskproServiceName = Some(journey.deskproServiceName),
     additionalScripts = Some(additionalScripts),
     headBlock = Some(timeoutDialog)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -6,12 +6,14 @@ verify-email-address.error.heading=This link has expired
 verify-email-address.error.paragraph=For security reasons the link must be used within a time limit.
 continuebutton.label=Yn eich blaen
 errorSummary.title=Mae problem wedi codi
+
 emailform.title=Beth yw’ch cyfeiriad e-bost? - Dilysu E-bost - GOV.UK
 emailform.error.title=Gwall: Beth yw’ch cyfeiriad e-bost? - Dilysu E-bost - GOV.UK
 emailform.heading=Beth yw’ch cyfeiriad e-bost?
 emailform.body=I gadarnhau mai’ch cyfeiriad e-bost chi yw hwn, byddwn yn anfon cod atoch
 emailform.continuebutton=Yn eich blaen
 emailform.error.invalidEmailFormat=Nodwch gyfeiriad e-bost yn y fformat cywir, megis enw@enghraifft.com
+emailform.input.label=Cyfeiriad e-bost
 
 passcodeform.title=Nodwch y cod i gadarnhau’r cyfeiriad e-bost - Dilysu E-bost - GOV.UK
 passcodeform.error.title=Gwall: Nodwch y cod i gadarnhau’r cyfeiriad e-bost - Dilysu E-bost - GOV.UK

--- a/it/test/connectors/EmailVerificationConnectorISpec.scala
+++ b/it/test/connectors/EmailVerificationConnectorISpec.scala
@@ -23,13 +23,9 @@ import models._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.Json
-import support.{IntegrationBaseSpec, WireMockHelper}
+import support.IntegrationBaseSpec
 
 class EmailVerificationConnectorISpec extends IntegrationBaseSpec with ScalaFutures with IntegrationPatience {
-
-  override def serviceConfig: Map[String, Any] = Map(
-    "microservice.services.email-verification.port" -> WireMockHelper.wireMockPort
-  )
 
   class Test {
     lazy val appConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]

--- a/it/test/connectors/EmailVerificationConnectorISpec.scala
+++ b/it/test/connectors/EmailVerificationConnectorISpec.scala
@@ -426,7 +426,8 @@ class EmailVerificationConnectorISpec extends IntegrationBaseSpec with ScalaFutu
           enterEmailUrl             = Some("http://example.com/enter-email"),
           backUrl                   = Some("http://example.com/back"),
           serviceTitle              = Some("Test Service Title"),
-          emailAddress              = Some("testemail@email.com")
+          emailAddress              = Some("testemail@email.com"),
+          labels                    = None
         )
 
         stubFor(
@@ -485,7 +486,8 @@ class EmailVerificationConnectorISpec extends IntegrationBaseSpec with ScalaFutu
           enterEmailUrl             = Some("http://example.com/enter-email"),
           backUrl                   = Some("http://example.com/back"),
           serviceTitle              = Some("Test Service Title"),
-          emailAddress              = Some("testemail@email.com")
+          emailAddress              = Some("testemail@email.com"),
+          labels                    = None
         )
 
         stubFor(
@@ -561,7 +563,8 @@ class EmailVerificationConnectorISpec extends IntegrationBaseSpec with ScalaFutu
           enterEmailUrl             = Some("http://example.com/enter-email"),
           backUrl                   = Some("http://example.com/back"),
           serviceTitle              = Some("Test Service Title"),
-          emailAddress              = Some("testemail@email.com")
+          emailAddress              = Some("testemail@email.com"),
+          labels                    = None
         )
 
         stubFor(

--- a/it/test/emailverification/EmailPasscodeWireMockSpec.scala
+++ b/it/test/emailverification/EmailPasscodeWireMockSpec.scala
@@ -16,7 +16,6 @@
 
 package emailverification
 
-import java.util.UUID
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import config.FrontendAppConfig
@@ -27,13 +26,14 @@ import play.api.http.HeaderNames
 import play.api.i18n.{Lang, MessagesApi}
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.DefaultWSCookie
+import play.api.test.Helpers._
 import play.api.test.Injecting
-import uk.gov.hmrc.gg.test.WireMockSpec
-import uk.gov.hmrc.play.it.SessionCookieEncryptionSupport
+import support.{IntegrationBaseSpec, SessionCookieEncryptionSupport}
 
+import java.util.UUID
 import scala.jdk.CollectionConverters._
 
-class EmailPasscodeWireMockSpec extends WireMockSpec with Injecting with SessionCookieEncryptionSupport with TableDrivenPropertyChecks {
+class EmailPasscodeWireMockSpec extends IntegrationBaseSpec with Injecting with SessionCookieEncryptionSupport with TableDrivenPropertyChecks {
 
   val messagesEn = app.injector.instanceOf[MessagesApi].preferred(Seq(Lang("en")))
   val messagesCy = app.injector.instanceOf[MessagesApi].preferred(Seq(Lang("cy")))

--- a/it/test/emailverification/JourneyControllerWireMockSpec.scala
+++ b/it/test/emailverification/JourneyControllerWireMockSpec.scala
@@ -16,15 +16,17 @@
 
 package emailverification
 
-import org.jsoup.Jsoup
-import uk.gov.hmrc.gg.test.WireMockSpec
 import com.github.tomakehurst.wiremock.client.WireMock._
+import org.jsoup.Jsoup
+import org.scalatest.OptionValues.convertOptionToValuable
 import play.api.libs.json.Json
+import play.api.test.Helpers._
+import support.IntegrationBaseSpec
 
 import java.util.UUID
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-class JourneyControllerWireMockSpec extends WireMockSpec {
+class JourneyControllerWireMockSpec extends IntegrationBaseSpec {
 
   "GET /journey/:journeyId/email" should {
     "return 200 OK and the email form" in new Setup {

--- a/it/test/emailverification/VerifyEmailWireMockSpec.scala
+++ b/it/test/emailverification/VerifyEmailWireMockSpec.scala
@@ -16,17 +16,19 @@
 
 package emailverification
 
-import java.util.{Base64, UUID}
 import com.github.tomakehurst.wiremock.client.WireMock._
-import play.api.http.HeaderNames
-import play.api.libs.json.Json
-import play.api.test.Injecting
-import uk.gov.hmrc.crypto.{ApplicationCrypto, PlainText}
-import uk.gov.hmrc.gg.test.WireMockSpec
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.TableDrivenPropertyChecks._
+import play.api.http.HeaderNames
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import play.api.test.Injecting
+import support.IntegrationBaseSpec
+import uk.gov.hmrc.crypto.{ApplicationCrypto, PlainText}
 
-class VerifyEmailWireMockSpec extends WireMockSpec with Injecting {
+import java.util.{Base64, UUID}
+
+class VerifyEmailWireMockSpec extends IntegrationBaseSpec with Injecting {
   private val continueUrl = "/continue-url"
   private def jsonToken(token: String) = Json
     .obj(

--- a/it/test/support/SessionCookieEncryptionSupport.scala
+++ b/it/test/support/SessionCookieEncryptionSupport.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package support
+
+import play.api.Configuration
+import play.api.http.HeaderNames
+import play.api.libs.crypto.CookieSigner
+import play.api.libs.ws.WSRequest
+import play.api.test.{HasApp, Injecting}
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter, PlainText, SymmetricCryptoFactory}
+
+trait SessionCookieEncryptionSupport extends Injecting {
+  self: HasApp =>
+
+  val signer: CookieSigner = inject[CookieSigner]
+  val SignSeparator = "-"
+  val mdtpSessionCookie = "mdtp"
+
+  lazy val cipher: Encrypter with Decrypter = SymmetricCryptoFactory.aesGcmCryptoFromConfig("cookie.encryption", inject[Configuration].underlying)
+
+  private def createPopulatedSessionCookie(payload: String): String = {
+    val signedPayload = signer.sign(payload) + SignSeparator + payload
+    val encryptedSignedPayload: String = cipher.encrypt(PlainText(signedPayload)).value
+    s"""$mdtpSessionCookie=$encryptedSignedPayload"""
+  }
+
+  implicit class WSRequestWithSession(request: WSRequest) {
+    def withSession(pair: (String, String)*): WSRequest =
+      request.addHttpHeaders(
+        HeaderNames.COOKIE -> createPopulatedSessionCookie(
+          pair.toSeq.map { case (k, v) => s"$k=$v" }.mkString("&")
+        )
+      )
+  }
+
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,8 +3,8 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.13.0"
-  private val playFrontendHmrcVersion = "12.6.0"
+  private val bootstrapVersion = "9.14.0"
+  private val playFrontendHmrcVersion = "12.7.0"
 
   private val compile = Seq(
     ws,
@@ -13,7 +13,6 @@ object AppDependencies {
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"                  %% "government-gateway-test-play-30" % "6.0.0"          % Test,
     "uk.gov.hmrc"                  %% "bootstrap-test-play-30"          % bootstrapVersion % Test,
     "com.fasterxml.jackson.module" %% "jackson-module-scala"            % "2.19.0"         % Test,
     "org.scalacheck"               %% "scalacheck"                      % "1.18.1"         % Test,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.playframework"  % "sbt-plugin"         % "3.0.7")
+addSbtPlugin("org.playframework"  % "sbt-plugin"         % "3.0.8")
 addSbtPlugin("uk.gov.hmrc"        % "sbt-distributables" % "2.6.0")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"      % "2.3.1")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"       % "2.5.4")

--- a/test/controllers/EmailVerificationControllerSpec.scala
+++ b/test/controllers/EmailVerificationControllerSpec.scala
@@ -22,7 +22,7 @@ import org.apache.commons.codec.binary.Base64.encodeBase64String
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import uk.gov.hmrc.crypto.Crypted
-import uk.gov.hmrc.gg.test.UnitSpec
+import support.UnitSpec
 import uk.gov.hmrc.play.bootstrap.tools.Stubs
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/controllers/EmailVerificationControllerSpec.scala
+++ b/test/controllers/EmailVerificationControllerSpec.scala
@@ -46,7 +46,7 @@ class EmailVerificationControllerSpec extends UnitSpec {
       val result: Future[Result] = controller.verify(encryptedAndEncodedToken)(FakeRequest())
 
       status(result)         shouldBe 303
-      redirectLocation(result) should contain("/error")
+      redirectLocation(result) should contain(routes.ErrorController.showErrorPage.url)
     }
   }
 

--- a/test/crypto/DecrypterSpec.scala
+++ b/test/crypto/DecrypterSpec.scala
@@ -16,16 +16,16 @@
 
 package crypto
 
-import java.util.UUID
-
 import ch.qos.logback.classic.Level
 import com.typesafe.config.ConfigFactory
 import controllers.Token
 import org.scalatest.LoneElement
-import play.api.Configuration
+import play.api.{Configuration, Logger}
+import support.UnitSpec
 import uk.gov.hmrc.crypto.{Crypted, PlainText, SymmetricCryptoFactory}
-import uk.gov.hmrc.gg.test.{LogCapturing, UnitSpec}
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
 
+import java.util.UUID
 import scala.util.Success
 
 class DecrypterSpec extends UnitSpec with LogCapturing with LoneElement {
@@ -36,7 +36,7 @@ class DecrypterSpec extends UnitSpec with LogCapturing with LoneElement {
     }
 
     "add a warning logging when deserialization fails" in new Setup {
-      withCaptureOfLoggingFrom[Decrypter] { logs =>
+      withCaptureOfLoggingFrom(Logger(decrypter.getClass)) { logs =>
         decrypter.decryptAs[Token](Crypted("foobar")).isFailure shouldBe true
 
         val warnLog = logs.filter(_.getLevel == Level.WARN).loneElement

--- a/test/support/UnitSpec.scala
+++ b/test/support/UnitSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package support
+
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.http.{HeaderNames, MimeTypes, Status}
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits, ResultExtractors, Writeables}
+
+trait UnitSpec
+    extends AnyWordSpec
+    with Matchers
+    with OptionValues
+    with HeaderNames
+    with Status
+    with MimeTypes
+    with DefaultAwaitTimeout
+    with ResultExtractors
+    with Writeables
+    with FutureAwaits
+    with MockitoSugar

--- a/test/views/EmailFormViewSpec.scala
+++ b/test/views/EmailFormViewSpec.scala
@@ -61,6 +61,7 @@ class EmailFormViewSpec extends UnitSpec with GuiceOneAppPerSuite {
 
         val document = Jsoup.parse(renderedView.body)
         document.select(".govuk-header__service-name").text() shouldBe "WelshTitle"
+        document.select("label[for=email]").text()            shouldBe "Cyfeiriad e-bost"
       }
     }
 
@@ -159,6 +160,7 @@ class EmailFormViewSpec extends UnitSpec with GuiceOneAppPerSuite {
 
         val document = Jsoup.parse(renderedView.body)
         document.select(".govuk-header__service-name").text() shouldBe "EnglishTitle"
+        document.select("label[for=email]").text()            shouldBe "Email address"
       }
     }
 

--- a/test/views/EmailFormViewSpec.scala
+++ b/test/views/EmailFormViewSpec.scala
@@ -23,7 +23,7 @@ import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.mvc.{Call, Cookie}
 import play.api.test.FakeRequest
 import play.twirl.api.Html
-import uk.gov.hmrc.gg.test.UnitSpec
+import support.UnitSpec
 import views.html.{EmailForm => EmailFormView}
 
 class EmailFormViewSpec extends UnitSpec with GuiceOneAppPerSuite {

--- a/test/views/EmailFormViewSpec.scala
+++ b/test/views/EmailFormViewSpec.scala
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import models.{EmailForm, Journey, MessageLabel, MessageLabels}
+import org.jsoup.Jsoup
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import play.api.mvc.{Call, Cookie}
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import uk.gov.hmrc.gg.test.UnitSpec
+import views.html.{EmailForm => EmailFormView}
+
+class EmailFormViewSpec extends UnitSpec with GuiceOneAppPerSuite {
+
+  val view: EmailFormView = app.injector.instanceOf[EmailFormView]
+
+  "when being rendered in Welsh" when {
+
+    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(Seq(Lang("cy")))
+
+    "a Welsh message exists in the labels" should {
+
+      "use the Welsh message from the Journey response" in {
+
+        val renderedView: Html = view(
+          EmailForm.form,
+          Call("POST", "/submit"),
+          Some(
+            Journey(
+              accessibilityStatementUrl = "/a11y",
+              deskproServiceName        = "deskproName",
+              enterEmailUrl             = None,
+              backUrl                   = None,
+              serviceTitle              = Some("serviceTitle"),
+              emailAddress              = None,
+              labels = Some(
+                MessageLabels(
+                  en = MessageLabel(pageTitle = Some("EnglishTitle"), userFacingServiceName = Some("EnglishServiceName")),
+                  cy = MessageLabel(pageTitle = Some("WelshTitle"), userFacingServiceName = Some("WelshServiceName"))
+                )
+              )
+            )
+          )
+        )(FakeRequest().withCookies(Cookie("PLAY_LANG", "cy")), messages)
+
+        val document = Jsoup.parse(renderedView.body)
+        document.select(".govuk-header__service-name").text() shouldBe "WelshTitle"
+      }
+    }
+
+    "a Welsh message DOES NOT exists in the labels" when {
+
+      "an English message exists" should {
+
+        "use the English message from the Journey response" in {
+
+          val renderedView: Html = view(
+            EmailForm.form,
+            Call("POST", "/submit"),
+            Some(
+              Journey(
+                accessibilityStatementUrl = "/a11y",
+                deskproServiceName        = "deskproName",
+                enterEmailUrl             = None,
+                backUrl                   = None,
+                serviceTitle              = Some("serviceTitle"),
+                emailAddress              = None,
+                labels = Some(
+                  MessageLabels(
+                    en = MessageLabel(pageTitle = Some("EnglishTitle"), userFacingServiceName = Some("EnglishServiceName")),
+                    cy = MessageLabel(pageTitle = None, userFacingServiceName = None)
+                  )
+                )
+              )
+            )
+          )(FakeRequest().withCookies(Cookie("PLAY_LANG", "cy")), messages)
+
+          val document = Jsoup.parse(renderedView.body)
+          document.select(".govuk-header__service-name").text() shouldBe "EnglishTitle"
+        }
+      }
+
+      "an English message does not exist in the labels" should {
+
+        "use the service title from the Journey response" in {
+
+          val renderedView: Html = view(
+            EmailForm.form,
+            Call("POST", "/submit"),
+            Some(
+              Journey(
+                accessibilityStatementUrl = "/a11y",
+                deskproServiceName        = "deskproName",
+                enterEmailUrl             = None,
+                backUrl                   = None,
+                serviceTitle              = Some("serviceTitle"),
+                emailAddress              = None,
+                labels = Some(
+                  MessageLabels(
+                    en = MessageLabel(pageTitle = None, userFacingServiceName = None),
+                    cy = MessageLabel(pageTitle = None, userFacingServiceName = None)
+                  )
+                )
+              )
+            )
+          )(FakeRequest().withCookies(Cookie("PLAY_LANG", "cy")), messages)
+
+          val document = Jsoup.parse(renderedView.body)
+          document.select(".govuk-header__service-name").text() shouldBe "serviceTitle"
+        }
+      }
+    }
+  }
+
+  "when being rendered in English" should {
+
+    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(Seq(Lang("en")))
+
+    "if a message exists in the 'labels' from the Journey response" should {
+
+      "return the english message" in {
+
+        val renderedView: Html = view(
+          EmailForm.form,
+          Call("POST", "/submit"),
+          Some(
+            Journey(
+              accessibilityStatementUrl = "/a11y",
+              deskproServiceName        = "deskproName",
+              enterEmailUrl             = None,
+              backUrl                   = None,
+              serviceTitle              = Some("serviceTitle"),
+              emailAddress              = None,
+              labels = Some(
+                MessageLabels(
+                  en = MessageLabel(pageTitle = Some("EnglishTitle"), userFacingServiceName = Some("EnglishServiceName")),
+                  cy = MessageLabel(pageTitle = Some("WelshTitle"), userFacingServiceName = Some("WelshServiceName"))
+                )
+              )
+            )
+          )
+        )(FakeRequest().withCookies(Cookie("PLAY_LANG", "en")), messages)
+
+        val document = Jsoup.parse(renderedView.body)
+        document.select(".govuk-header__service-name").text() shouldBe "EnglishTitle"
+      }
+    }
+
+    "if a message DOES NOT exist in the 'labels' from the Journey response" should {
+
+      "return the serviceTitle message" in {
+
+        val renderedView: Html = view(
+          EmailForm.form,
+          Call("POST", "/submit"),
+          Some(
+            Journey(
+              accessibilityStatementUrl = "/a11y",
+              deskproServiceName        = "deskproName",
+              enterEmailUrl             = None,
+              backUrl                   = None,
+              serviceTitle              = Some("serviceTitle"),
+              emailAddress              = None,
+              labels                    = None
+            )
+          )
+        )(FakeRequest().withCookies(Cookie("PLAY_LANG", "en")), messages)
+
+        val document = Jsoup.parse(renderedView.body)
+        document.select(".govuk-header__service-name").text() shouldBe "serviceTitle"
+      }
+    }
+  }
+}

--- a/test/views/HybridPasscodeFormViewSpec.scala
+++ b/test/views/HybridPasscodeFormViewSpec.scala
@@ -23,7 +23,7 @@ import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.twirl.api.Html
-import uk.gov.hmrc.gg.test.UnitSpec
+import support.UnitSpec
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
 import views.html.{HybridPasscodeForm => HybridPasscodeFormView}
 

--- a/test/views/HybridPasscodeFormViewSpec.scala
+++ b/test/views/HybridPasscodeFormViewSpec.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import models.{EmailForm, Journey, MessageLabel, MessageLabels}
+import org.jsoup.Jsoup
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import play.api.mvc.Cookie
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import uk.gov.hmrc.gg.test.UnitSpec
+import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl
+import views.html.{HybridPasscodeForm => HybridPasscodeFormView}
+
+class HybridPasscodeFormViewSpec extends UnitSpec with GuiceOneAppPerSuite {
+
+  val view: HybridPasscodeFormView = app.injector.instanceOf[HybridPasscodeFormView]
+
+  "when being rendered in Welsh" when {
+
+    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(Seq(Lang("cy")))
+
+    "a Welsh message exists in the labels" should {
+
+      "use the Welsh message from the Journey response" in {
+
+        val renderedView: Html = view(
+          EmailForm.form,
+          "journeyId",
+          RedirectUrl("/redirect"),
+          "origin",
+          "enterEmailUrl",
+          Journey(
+            accessibilityStatementUrl = "/a11y",
+            deskproServiceName        = "deskproName",
+            enterEmailUrl             = None,
+            backUrl                   = None,
+            serviceTitle              = Some("serviceTitle"),
+            emailAddress              = None,
+            labels = Some(
+              MessageLabels(
+                en = MessageLabel(pageTitle = Some("EnglishTitle"), userFacingServiceName = Some("EnglishServiceName")),
+                cy = MessageLabel(pageTitle = Some("WelshTitle"), userFacingServiceName = Some("WelshServiceName"))
+              )
+            )
+          )
+        )(FakeRequest().withCookies(Cookie("PLAY_LANG", "cy")), messages)
+
+        val document = Jsoup.parse(renderedView.body)
+        document.select(".govuk-header__service-name").text() shouldBe "WelshTitle"
+      }
+    }
+
+    "a Welsh message DOES NOT exists in the labels" when {
+
+      "an English message exists" should {
+
+        "use the English message from the Journey response" in {
+
+          val renderedView: Html = view(
+            EmailForm.form,
+            "journeyId",
+            RedirectUrl("/redirect"),
+            "origin",
+            "enterEmailUrl",
+            Journey(
+              accessibilityStatementUrl = "/a11y",
+              deskproServiceName        = "deskproName",
+              enterEmailUrl             = None,
+              backUrl                   = None,
+              serviceTitle              = Some("serviceTitle"),
+              emailAddress              = None,
+              labels = Some(
+                MessageLabels(
+                  en = MessageLabel(pageTitle = Some("EnglishTitle"), userFacingServiceName = Some("EnglishServiceName")),
+                  cy = MessageLabel(pageTitle = None, userFacingServiceName = None)
+                )
+              )
+            )
+          )(FakeRequest().withCookies(Cookie("PLAY_LANG", "cy")), messages)
+
+          val document = Jsoup.parse(renderedView.body)
+          document.select(".govuk-header__service-name").text() shouldBe "EnglishTitle"
+        }
+      }
+
+      "an English message does not exist in the labels" should {
+
+        "use the service title from the Journey response" in {
+
+          val renderedView: Html = view(
+            EmailForm.form,
+            "journeyId",
+            RedirectUrl("/redirect"),
+            "origin",
+            "enterEmailUrl",
+            Journey(
+              accessibilityStatementUrl = "/a11y",
+              deskproServiceName        = "deskproName",
+              enterEmailUrl             = None,
+              backUrl                   = None,
+              serviceTitle              = Some("serviceTitle"),
+              emailAddress              = None,
+              labels = Some(
+                MessageLabels(
+                  en = MessageLabel(pageTitle = None, userFacingServiceName = None),
+                  cy = MessageLabel(pageTitle = None, userFacingServiceName = None)
+                )
+              )
+            )
+          )(FakeRequest().withCookies(Cookie("PLAY_LANG", "cy")), messages)
+
+          val document = Jsoup.parse(renderedView.body)
+          document.select(".govuk-header__service-name").text() shouldBe "serviceTitle"
+        }
+      }
+    }
+  }
+
+  "when being rendered in English" should {
+
+    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(Seq(Lang("en")))
+
+    "if a message exists in the 'labels' from the Journey response" should {
+
+      "return the english message" in {
+
+        val renderedView: Html = view(
+          EmailForm.form,
+          "journeyId",
+          RedirectUrl("/redirect"),
+          "origin",
+          "enterEmailUrl",
+          Journey(
+            accessibilityStatementUrl = "/a11y",
+            deskproServiceName        = "deskproName",
+            enterEmailUrl             = None,
+            backUrl                   = None,
+            serviceTitle              = Some("serviceTitle"),
+            emailAddress              = None,
+            labels = Some(
+              MessageLabels(
+                en = MessageLabel(pageTitle = Some("EnglishTitle"), userFacingServiceName = Some("EnglishServiceName")),
+                cy = MessageLabel(pageTitle = Some("WelshTitle"), userFacingServiceName = Some("WelshServiceName"))
+              )
+            )
+          )
+        )(FakeRequest().withCookies(Cookie("PLAY_LANG", "en")), messages)
+
+        val document = Jsoup.parse(renderedView.body)
+        document.select(".govuk-header__service-name").text() shouldBe "EnglishTitle"
+      }
+    }
+
+    "if a message DOES NOT exist in the 'labels' from the Journey response" should {
+
+      "return the serviceTitle message" in {
+
+        val renderedView: Html = view(
+          EmailForm.form,
+          "journeyId",
+          RedirectUrl("/redirect"),
+          "origin",
+          "enterEmailUrl",
+          Journey(
+            accessibilityStatementUrl = "/a11y",
+            deskproServiceName        = "deskproName",
+            enterEmailUrl             = None,
+            backUrl                   = None,
+            serviceTitle              = Some("serviceTitle"),
+            emailAddress              = None,
+            labels                    = None
+          )
+        )(FakeRequest().withCookies(Cookie("PLAY_LANG", "en")), messages)
+
+        val document = Jsoup.parse(renderedView.body)
+        document.select(".govuk-header__service-name").text() shouldBe "serviceTitle"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Parses the 'labels' attribute from the email-verification journey response. If it includes Welsh messages and the PLAY_LANG cookie is set to Welsh then it will render the Welsh content. Other wise it uses English.

Requires the associated BE PR here:
- https://github.com/hmrc/email-verification/pull/121

This change is backwards compatible with any pre-existing Journey Data models as the Labels have been added as an Option.